### PR TITLE
UX: allow component to change lock icons in category boxes

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -6,6 +6,8 @@ import { isRTL } from "discourse/lib/text-direction";
 import { h } from "virtual-dom";
 import getURL from "discourse-common/lib/get-url";
 import categoryTitleLink from "discourse/components/category-title-link";
+import categoriesBoxes from "discourse/components/categories-boxes";
+import categoriesBoxesWithTopics from "discourse/components/categories-boxes-with-topics";
 import I18n from "I18n";
 import { get } from "@ember/object";
 import { escapeExpression } from "discourse/lib/utilities";
@@ -19,6 +21,14 @@ export default {
       let lockIcon = settings.category_lock_icon || "lock";
 
       categoryTitleLink.reopen({
+        lockIcon: lockIcon,
+      });
+
+      categoriesBoxes.reopen({
+        lockIcon: lockIcon,
+      });
+
+      categoriesBoxesWithTopics.reopen({
         lockIcon: lockIcon,
       });
 


### PR DESCRIPTION
context: https://meta.discourse.org/t/unable-to-alter-the-lock-icon-in-category-boxes/212133

I sent a PR to fix the core side of this here

https://github.com/discourse/discourse/pull/15309

This PR makes the same adjustment here 

https://github.com/discourse/discourse-category-icons/blob/main/javascripts/discourse/initializers/category-icons.js#L21-L23

to the `categories-boxes` and `categories-boxes-with-topics` components.