### PR TITLE
FEATURE: Add support for native emojis + Discourse emojis + use category logo as icon

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,17 +1,49 @@
 span.category-badge-icon {
   display: inline-flex;
   align-self: center;
+  font-size: var(--font-up-2);
+  &:hover {
+    text-decoration: none;
+  }
   .d-icon {
     opacity: 1;
-    font-size: 1.3em;
+    font-size: var(--font-0);
   }
 }
 
-.categories-list .category h3 .d-icon,
-.badge-wrapper .badge-category .d-icon,
-.select-kit .select-kit-header .selected-name .name .badge-wrapper .d-icon {
-  margin-right: 5px;
-  margin-left: 0px;
+.category-badge-icon__emoji {
+  max-width: 1.25em;
+  max-height: 1.25em;
+}
+
+span.category-badge-logo {
+  img {
+    max-width: 2.25em;
+    max-height: 2.25em;
+  }
+  margin-right: 0.375em;
+}
+
+a.badge-wrapper {
+  &:hover {
+    .category-badge-icon {
+      text-decoration: none;
+    }
+  }
+}
+
+.badge-wrapper .badge-category {
+  align-items: center;
+}
+
+.badge-wrapper .badge-category {
+  .category-badge-icon {
+    margin-right: 5px;
+    margin-left: 0px;
+    .d-icon {
+      margin-right: 0;
+    }
+  }
 }
 
 .badge-wrapper.bullet span.category-badge-icon .d-icon,

--- a/common/common.scss
+++ b/common/common.scss
@@ -36,19 +36,20 @@ a.badge-wrapper {
   align-items: center;
 }
 
-.badge-wrapper .badge-category {
+.badge-wrapper:not(.box) .badge-category {
   .category-badge-icon {
     margin-right: 5px;
     margin-left: 0px;
     .d-icon {
       margin-right: 0;
+      color: var(--category-color);
     }
   }
 }
 
 .badge-wrapper.bullet span.category-badge-icon .d-icon,
 .categories-list .category .category-icon .d-icon {
-  color: inherit;
+  color: var(--category-color);
 }
 
 .categories-list .category-box-heading h3 div {
@@ -57,4 +58,12 @@ a.badge-wrapper {
 
 .subcategory .category-icon-widget {
   display: none;
+}
+
+.badge-wrapper.bullet,
+.badge-wrapper.bar {
+  .badge-category-parent-bg,
+  .badge-category-bg {
+    display: none;
+  }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,49 +1,34 @@
 span.category-badge-icon {
-  display: inline-flex;
-  align-self: center;
-  font-size: var(--font-up-2);
-  &:hover {
-    text-decoration: none;
-  }
+  display: inline; // to prevent varying line heights
   .d-icon {
     opacity: 1;
-    font-size: var(--font-0);
+    font-size: var(--font-up-2);
   }
 }
 
 .category-badge-icon__emoji {
-  max-width: 1.25em;
-  max-height: 1.25em;
-}
-
-span.category-badge-logo {
+  width: 1em;
+  font-size: var(--font-up-2);
+  line-height: 0;
   img {
-    max-width: 2.25em;
-    max-height: 2.25em;
-  }
-  margin-right: 0.375em;
-}
-
-a.badge-wrapper {
-  &:hover {
-    .category-badge-icon {
-      text-decoration: none;
-    }
+    width: 100%;
+    height: auto;
   }
 }
 
-.badge-wrapper .badge-category {
-  align-items: center;
+// emoji visible when category style set to box
+
+.badge-wrapper.box span .category-badge-icon__emoji {
+  overflow: visible;
 }
 
-.badge-wrapper:not(.box) .badge-category {
-  .category-badge-icon {
+.categories-list .category h3,
+.badge-wrapper .badge-category,
+.select-kit .select-kit-header .selected-name .name .badge-wrapper {
+  .d-icon,
+  .category-badge-icon__emoji {
     margin-right: 5px;
     margin-left: 0px;
-    .d-icon {
-      margin-right: 0;
-      color: var(--category-color);
-    }
   }
 }
 
@@ -60,10 +45,15 @@ a.badge-wrapper {
   display: none;
 }
 
-.badge-wrapper.bullet,
-.badge-wrapper.bar {
-  .badge-category-parent-bg,
-  .badge-category-bg {
-    display: none;
+// category logo as icon
+
+span.category-badge-logo {
+  img {
+    max-width: 1.5em;
+    width: 100%;
+    height: auto;
   }
+  height: 0;
+  overflow: visible;
+  margin-right: 0.375em;
 }

--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -83,6 +83,7 @@ export default {
         let parentCat = null;
         let categoryDir = "";
         let categoryLogo = get(category, "uploaded_logo");
+        let categoryColor = get(category, "color");
 
         if (!opts.hideParent) {
           parentCat = Category.findById(get(category, "parent_category_id"));
@@ -123,9 +124,9 @@ export default {
           /// Add custom category icon from theme settings
           let iconItem = getIconItem(category.slug);
           if (iconItem) {
-            let itemColor = iconItem[2]
-              ? `style="color: ${iconItem[2]}"`
-              : `style="color: #${color}"`;
+            // let itemColor = iconItem[2]
+            //   ? `style="color: ${iconItem[2]}"`
+            //   : `style="color: #${color}"`;
             // check if native emoji
             const emojiSet = helperContext().siteSettings.emoji_set;
             let itemIcon = /\p{Extended_Pictographic}/u.test(iconItem[1])
@@ -143,7 +144,7 @@ export default {
                 /\p{Extended_Pictographic}/u.test(iconItem[1]) === false
               ? iconHTML(iconItem[1])
               : "";
-            html += `<span ${itemColor} class="category-badge-icon">${itemIcon}</span>`;
+            html += `<span style="--category-color: #${categoryColor}" class="category-badge-icon">${itemIcon}</span>`;
             /// End custom category icon
           }
         } else if (categoryLogo) {

--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -124,34 +124,41 @@ export default {
           /// Add custom category icon from theme settings
           let iconItem = getIconItem(category.slug);
           if (iconItem) {
-            // let itemColor = iconItem[2]
-            //   ? `style="color: ${iconItem[2]}"`
-            //   : `style="color: #${color}"`;
+            let itemColor = iconItem[2]
+              ? iconItem[2].match(/categoryColo(u*)r/)
+                ? `color: #${color};`
+                : `color: ${iconItem[2]};`
+              : "";
             // check if native emoji
             const emojiSet = helperContext().siteSettings.emoji_set;
             let itemIcon = /\p{Extended_Pictographic}/u.test(iconItem[1])
               ? iconItem[1]
               : // check if hosted emoji
               iconItem[1].charAt(0) == ":"
-              ? `<img class="category-badge-icon__emoji" src="` +
+              ? `<img src="` +
                 getURL(
                   `${emojiBasePath()}/${emojiSet}/${iconItem[1]
                     .replace(/:t/, "/")
                     .replace(/:/g, "")}.png`
                 ) +
                 `" />`
-              : iconItem[1] !== "" &&
-                /\p{Extended_Pictographic}/u.test(iconItem[1]) === false
+              : iconItem[1] !== ""
               ? iconHTML(iconItem[1])
               : "";
-            html += `<span style="--category-color: #${categoryColor}" class="category-badge-icon">${itemIcon}</span>`;
+            let emojiClass = "";
+            if (
+              /\p{Extended_Pictographic}/u.test(iconItem[1]) ||
+              iconItem[1].charAt(0) == ":"
+            ) {
+              emojiClass = `category-badge-icon__emoji`;
+            }
+            html += `<span style="${itemColor} --category-color: #${categoryColor}" class="category-badge-icon ${emojiClass}">${itemIcon}</span>`;
             /// End custom category icon
           }
+          // Add category logo from theme settings
         } else if (categoryLogo) {
           html += `<span class="category-badge-logo"><img src="${categoryLogo.url}" /></span>`;
         }
-
-        // Add category logo from theme settings
 
         let categoryName = escapeExpression(get(category, "name"));
 
@@ -195,7 +202,14 @@ export default {
                 ? `color: #${attrs.category.color}`
                 : `color: ${iconItem[2]}`
               : "";
-            let itemIcon = iconItem[1] !== "" ? iconNode(iconItem[1]) : "";
+            let itemIcon = /\p{Extended_Pictographic}/u.test(iconItem[1])
+              ? ""
+              : iconItem[1].charAt(0) == ":"
+              ? ""
+              : iconItem[1] !== ""
+              ? iconNode(iconItem[1])
+              : "";
+
             return h("span.category-icon", { style: itemColor }, itemIcon);
           }
         },

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@ category_icon_list:
   default: "help,question-circle,#CC0000,partial|"
   type: "list"
   list_type: "simple"
-  description: 'Enter comma-delimited configuration for categories, in the format "slug,icon,color,match". Colour in format #123456 or "categoryColor" to use the default color for the category (same as the Badge color). If  match is "partial" then the slug need only partially match the category-slug, otherwise an exact match is required'
+  description: '  Enter comma-delimited configuration for categories<br>Format: "slug,icon,color,partial"<br>slug — The category slug.<br>icon — Can be either (1) Font Awesome icon, (2) a singular unicode character "😀", or (3) a forum emoji formatted like ":grinning:"<br>color (optional) — Color for the icon. Only works for Font Awesome, not emojis. Use a hex code with the "#" character. Default color is the category/badge color.<br>partial (optional) — Write "partial" if the slug only need only partially match the category-slug, otherwise an exact match is required. Useful for subcategories with identical names.'
 svg_icons:
   default: "question-circle"
   type: "list"
@@ -11,3 +11,7 @@ svg_icons:
 category_lock_icon:
   default: ""
   description: "Enter the name of a FontAwesome 5 icon to display instead of the lock icon next to private categories."
+use_category_logo:
+  type: bool
+  default: false
+  description: "Use the category's uploaded logo as its icon.<br><br>Overrides Font Awesome icons and emojis.<br><br>Category logos can be uploaded through individual category settings."

--- a/settings.yml
+++ b/settings.yml
@@ -3,14 +3,6 @@ category_icon_list:
   type: "list"
   list_type: "simple"
   description: '  Enter comma-delimited configuration for categories<br>Format: "slug,icon,color,partial"<br>slug — The category slug.<br>icon — Can be either (1) Font Awesome icon, (2) a singular unicode character "😀", or (3) a forum emoji formatted like ":grinning:"<br>color (optional) — Color for the icon. Only works for Font Awesome, not emojis. Use a hex code with the "#" character. Default color is the category/badge color.<br>partial (optional) — Write "partial" if the slug only need only partially match the category-slug, otherwise an exact match is required. Useful for subcategories with identical names.'
-svg_icons:
-  default: "question-circle"
-  type: "list"
-  list_type: "compact"
-  description: "List of FontAwesome 5 icons used in this theme component"
-category_lock_icon:
-  default: ""
-  description: "Enter the name of a FontAwesome 5 icon to display instead of the lock icon next to private categories."
 use_category_logo:
   type: bool
   default: false

--- a/settings.yml
+++ b/settings.yml
@@ -2,8 +2,16 @@ category_icon_list:
   default: "help,question-circle,#CC0000,partial|"
   type: "list"
   list_type: "simple"
-  description: '  Enter comma-delimited configuration for categories<br>Format: "slug,icon,color,partial"<br>slug — The category slug.<br>icon — Can be either (1) Font Awesome icon, (2) a singular unicode character "😀", or (3) a forum emoji formatted like ":grinning:"<br>color (optional) — Color for the icon. Only works for Font Awesome, not emojis. Use a hex code with the "#" character. Default color is the category/badge color.<br>partial (optional) — Write "partial" if the slug only need only partially match the category-slug, otherwise an exact match is required. Useful for subcategories with identical names.'
+  description: '  Enter comma-delimited configuration for categories<br><br>Format: "slug,icon,color,partial"<br><br>slug — The category slug.<br><br>icon — Can be either (1) a Font Awesome icon, (2) a singular unicode character "😀", or (3) a forum emoji formatted like ":grinning:"<br><br>color (optional) — Color for the icon. Use a hex code with the "#" character. Default color is the category color.<br><br>partial (optional) — A color must be set first to activate this. Write "partial" if the slug only needs to partially match the category-slug, otherwise an exact match is required. Useful for subcategories with identical names.'
+svg_icons:
+  default: "question-circle"
+  type: "list"
+  list_type: "compact"
+  description: "List of FontAwesome 5 icons used in this theme component"
+category_lock_icon:
+  default: ""
+  description: "Enter the name of a FontAwesome 5 icon to display instead of the lock icon next to private categories."
 use_category_logo:
   type: bool
   default: false
-  description: "Use the category's uploaded logo as its icon.<br><br>Overrides Font Awesome icons and emojis.<br><br>Category logos can be uploaded through individual category settings."
+  description: "Use the category's uploaded logo as its icon.<br><br><strong>Overrides</strong> Font Awesome icons and emojis.<br><br>Category logos can be uploaded through individual category settings."


### PR DESCRIPTION
https://meta.discourse.org/t/category-icons/104683/179

## Emoji support

![image](https://user-images.githubusercontent.com/37538241/216892242-2b70f89b-90a4-4d72-9b9b-0cb677f4f39d.png)

![image](https://user-images.githubusercontent.com/37538241/216892256-2c06d9df-c470-460c-b2f4-4cec76ddc6ea.png)

## Logo support

![image](https://user-images.githubusercontent.com/37538241/216892281-54bbae69-f14d-420d-9abc-1fdb3658f126.png)

<img width="791" alt="image" src="https://user-images.githubusercontent.com/37538241/216892302-d6563f6e-f8ed-4023-90d8-0ca07ee632f3.png">
