### PR TITLE
DEV: add component for cross-theme compatibility

### DIFF
--- a/javascripts/discourse/components/category-icon.js
+++ b/javascripts/discourse/components/category-icon.js
@@ -1,0 +1,16 @@
+/* This component is used in the Category banners theme component */
+/* https://meta.discourse.org/t/category-banners/86241 */
+import MountWidget from "discourse/components/mount-widget";
+
+export default class CategoryIcon extends MountWidget {
+  widget = "category-icon";
+
+  buildArgs() {
+    return { category: this.category };
+  }
+
+  didReceiveAttrs() {
+    super.didReceiveAttrs();
+    this.queueRerender();
+  }
+}


### PR DESCRIPTION
This adds a component for use in the category banners theme component, which is being converted from a widget to a component. See https://github.com/discourse/discourse-category-banners/pull/28