### PR TITLE
DEV: add class name to component wrapper

### DIFF
--- a/javascripts/discourse/components/category-icon.js
+++ b/javascripts/discourse/components/category-icon.js
@@ -4,6 +4,7 @@ import MountWidget from "discourse/components/mount-widget";
 
 export default class CategoryIcon extends MountWidget {
   widget = "category-icon";
+  classNames = ["category-icon-widget-wrapper"];
 
   buildArgs() {
     return { category: this.category };


### PR DESCRIPTION
I'm using this class name for styles in the category banners component. (related PR https://github.com/discourse/discourse-category-banners/pull/29)