### PR TITLE
FEATURE: Add support in sidebar

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -190,21 +190,27 @@ export default {
             const klass = new CategorySectionLink({
               category,
               topicTrackingState: this.topicTrackingState,
-              currentUser: this.currentUser
+              currentUser: this.currentUser,
             });
 
             const item = getIconItem(klass.category.slug);
 
             if (item) {
-              const { prefixType, prefixValue, prefixColor, prefixBadge } = klass;
+              const { prefixType, prefixValue, prefixColor, prefixBadge } =
+                klass;
 
               const icon = item[1] || prefixValue;
-              let color = item[2] && item[2].match(/categoryColo(u*)r/g) ? prefixColor : item[2];
+              let color =
+                item[2] && item[2].match(/categoryColo(u*)r/g)
+                  ? prefixColor
+                  : item[2];
               if (color[0] === "#") {
                 color = color.slice(1);
               }
 
-              Object.defineProperties(klass, Object.getOwnPropertyDescriptors({
+              Object.defineProperties(
+                klass,
+                Object.getOwnPropertyDescriptors({
                   get prefixType() {
                     return icon ? "icon" : prefixType;
                   },
@@ -225,7 +231,7 @@ export default {
 
             return klass;
           });
-        }
+        },
       });
     });
   },


### PR DESCRIPTION
This adds support in the sidebar.
Tested on the latest Discourse version ([9a34625cb8](https://github.com/discourse/discourse/commits/9a34625cb8c1592304b14115f08143ef18986853))

I'm unsure if this is the proper way to overwrite glimmer components.
I could not find a better way (not a big fan of reusing original code)

Original code: [components/sidebar/common/categories-section.js](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/sidebar/common/categories-section.js#L52-L59)
Requested here: https://meta.discourse.org/t/category-icons/104683/195?u=arkshine

### Before:
![image](https://user-images.githubusercontent.com/360640/233090705-1d1f2888-5d25-45c7-8f1a-732e5d3f95d6.png)


### After:
![image](https://user-images.githubusercontent.com/360640/233084477-5f3814af-42d2-4b7a-a541-d788bdcbb578.png)
#### User
![image](https://user-images.githubusercontent.com/360640/233091232-4332526d-de62-42df-b694-1b7fabec7f81.png)
#### Anonymous
![image](https://user-images.githubusercontent.com/360640/233091865-2368076d-022b-4a95-85ee-9f3f7f58a002.png)

