### PR TITLE
UX: escape category title

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -63,7 +63,9 @@ export default {
 
       function categoryIconsRenderer(category, opts) {
         let siteSettings = helperContext().siteSettings;
-        let descriptionText = get(category, "description_text");
+        let descriptionText = escapeExpression(
+          get(category, "description_text")
+        );
         let restricted = get(category, "read_restricted");
         let url = opts.url
           ? opts.url


### PR DESCRIPTION
This follows the core fix added here: https://github.com/discourse/discourse/commit/b65f2818423de8d6809e9a0e7b73f93a0fd5f710

This is primarily for the uncategorized category description, which isn't escaped upstream like normal category descriptions. 