### PR TITLE
FIX: Render sidebar icons when no color is defined

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -172,7 +172,7 @@ export default {
         categoryThemeList.forEach((str) => {
           const [slug, icon, color, match] = str.split(",");
 
-          if (slug && icon && color) {
+          if (slug && icon) {
             const category = site.categories.find((cat) => {
               if (match === "partial") {
                 return cat.slug.toLowerCase().includes(slug.toLowerCase());
@@ -186,9 +186,10 @@ export default {
                 categoryId: category.id,
                 prefixType: "icon",
                 prefixValue: icon,
+                prefixColor: color ? color : category.color,
               };
 
-              if (!color.match(/categoryColo(u*)r/g)) {
+              if (color && !color.match(/categoryColo(u*)r/g)) {
                 opts.prefixColor = color.replace(/^#/, "");
               }
 

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@ category_icon_list:
   default: "help,question-circle,#CC0000,partial|"
   type: "list"
   list_type: "simple"
-  description: 'Enter comma-delimited configuration for categories, in the format "slug,icon,color,match". Colour in format #123456 or "categoryColor" to use the default color for the category (same as the Badge color). If  match is "partial" then the slug need only partially match the category-slug, otherwise an exact match is required'
+  description: 'Enter comma-delimited configuration for categories, in the format "slug,icon,color,match". Color can be in hex format (#123456) or left blank, then the default color for the category is used (same as the Badge color). If  match is "partial" then the slug need only partially match the category-slug, otherwise an exact match is required'
 svg_icons:
   default: "question-circle"
   type: "list"


### PR DESCRIPTION
Without color definition the category color will be used. That could not always be the desired outcome, but it's the behavior on  the default badges, so probably best to align it.