### PR TITLE
FIX: Render sidebar icons when no color is defined

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -172,7 +172,7 @@ export default {
         categoryThemeList.forEach((str) => {
           const [slug, icon, color, match] = str.split(",");
 
-          if (slug && icon && color) {
+          if (slug && icon) {
             const category = site.categories.find((cat) => {
               if (match === "partial") {
                 return cat.slug.toLowerCase().includes(slug.toLowerCase());
@@ -186,9 +186,10 @@ export default {
                 categoryId: category.id,
                 prefixType: "icon",
                 prefixValue: icon,
+                prefixColor: color ? color : category.color,
               };
 
-              if (!color.match(/categoryColo(u*)r/g)) {
+              if (color && !color.match(/categoryColo(u*)r/g)) {
                 opts.prefixColor = color.replace(/^#/, "");
               }
 

--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -186,11 +186,12 @@ export default {
                 categoryId: category.id,
                 prefixType: "icon",
                 prefixValue: icon,
-                prefixColor: color ? color : category.color,
+                prefixColor: color,
               };
 
-              if (color && !color.match(/categoryColo(u*)r/g)) {
-                opts.prefixColor = color.replace(/^#/, "");
+              // Fix for obsolete color declaration
+              if (color && color.match(/categoryColo(u*)r/g)) {
+                opts.prefixColor = category.color;
               }
 
               api.registerCustomCategorySectionLinkPrefix(opts);

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@ category_icon_list:
   default: "help,question-circle,#CC0000,partial|"
   type: "list"
   list_type: "simple"
-  description: 'Enter comma-delimited configuration for categories, in the format "slug,icon,color,match". Colour in format #123456 or "categoryColor" to use the default color for the category (same as the Badge color). If  match is "partial" then the slug need only partially match the category-slug, otherwise an exact match is required'
+  description: 'Enter comma-delimited configuration for categories, in the format "slug,icon,color,match". Color can be in hex format (#123456) or left blank, then the default color for the category is used (same as the Badge color). If  match is "partial" then the slug need only partially match the category-slug, otherwise an exact match is required'
 svg_icons:
   default: "question-circle"
   type: "list"


### PR DESCRIPTION
Using categoryColor in the settings list is obsolete as the category color will be applied by default. 

This is a fix for existing instances still using the value that corrects the color on the sidebar icons . I'm not sure what's the code style to handle such regressions. I added a comment that seemed most clear to me.

Using categoryColor as value actually also fails on the default badges now, but silently as it's applied to an inline style:
![image](https://github.com/discourse/discourse-category-icons/assets/26887899/b65e03d5-ef01-4c00-8ddd-927d1c4b87a2)

