### PR TITLE
FIX: Render legacy color declaration

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -186,11 +186,12 @@ export default {
                 categoryId: category.id,
                 prefixType: "icon",
                 prefixValue: icon,
-                prefixColor: color ? color : category.color,
+                prefixColor: color,
               };
 
-              if (color && !color.match(/categoryColo(u*)r/g)) {
-                opts.prefixColor = color.replace(/^#/, "");
+              // Fix for legacy color declaration
+              if (color?.match(/categoryColo(u*)r/g)) {
+                opts.prefixColor = category.color;
               }
 
               api.registerCustomCategorySectionLinkPrefix(opts);


### PR DESCRIPTION
Using categoryColor in the settings list is obsolete as the category color will be applied by default.

This is a fix for the sidebar icons, for existing instances still using the value. I'm not sure what's the code style to handle such regressions. I added a comment as it seemed most clear to me.

Using categoryColor as value actually also fails on the new default badges, but silently as it's applied to an inline style:

![Screenshot from 2024-06-15 22-15-38](https://github.com/discourse/discourse-category-icons/assets/26887899/4ef18928-f536-48d0-a197-6ee68f0052f0)
