### PR TITLE
DEV: Migrate settings defaults from deprecated icon names

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -1,9 +1,9 @@
 category_icon_list:
-  default: "help,question-circle,#CC0000,partial|"
+  default: "help,circle-question,#CC0000,partial|"
   type: "list"
   list_type: "simple"
 svg_icons:
-  default: "question-circle"
+  default: "circle-question"
   type: "list"
   list_type: "compact"
 category_lock_icon:


### PR DESCRIPTION
This PR migrates deprecated Font Awesome icon names saved in settings as defaults. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.