### PR TITLE
FIX: broken specs

### DIFF
--- a/javascripts/discourse/initializers/category-icons.js
+++ b/javascripts/discourse/initializers/category-icons.js
@@ -1,7 +1,4 @@
 import { get } from "@ember/object";
-import categoriesBoxes from "discourse/components/categories-boxes";
-import categoriesBoxesWithTopics from "discourse/components/categories-boxes-with-topics";
-import categoryTitleLink from "discourse/components/category-title-link";
 import getURL from "discourse/lib/get-url";
 import CategoryHashtagType from "discourse/lib/hashtag-types/category";
 import { helperContext } from "discourse/lib/helpers";
@@ -39,18 +36,6 @@ export default {
     withPluginApi("0.8.26", (api) => {
       let categoryThemeList = settings.category_icon_list.split("|");
       let lockIcon = settings.category_lock_icon || "lock";
-
-      categoryTitleLink.reopen({
-        lockIcon,
-      });
-
-      categoriesBoxes.reopen({
-        lockIcon,
-      });
-
-      categoriesBoxesWithTopics.reopen({
-        lockIcon,
-      });
 
       function getIconItem(categorySlug) {
         if (!categorySlug) {


### PR DESCRIPTION
Since https://github.com/discourse/discourse/commit/92312eec7b14b421b872b0f20d6f3363c9e92fd6 this theme has been broken with the following error:

```
TypeError: s.default.reopen is not a function
```

Removing all these reopen, all the tests pass. Im also wondering if we still need this in core (app/assets/javascripts/discourse/app/components/category-title-link.gjs):

```
// icon name defined on prototype so it can be easily overridden in theme components
CategoryTitleLink.prototype.lockIcon = "lock";
```

It doesn’t seem to be used anywhere.